### PR TITLE
problem: sql queries use a lot of memory

### DIFF
--- a/csirtg_smrt/archiver.py
+++ b/csirtg_smrt/archiver.py
@@ -105,6 +105,7 @@ class Archiver(object):
         logger.info("Caching archived indicators for provider {}".format(provider))
         q = self.handle().query(Indicator).filter_by(provider=provider)
         q = q.options(load_only("indicator", "group", "tags", "firsttime", "lasttime"))
+        q = q.yield_per(1000)
         for i in q:
             self.memcache[i.indicator] = (i.group, i.tags, i.firsttime, i.lasttime)
         logger.info("Cached provider {} in memory, {} objects".format(provider, len(self.memcache)))


### PR DESCRIPTION
By default sql results are not streamed, this causes this function to
use gigabytes of ram before it even hits the cache building.