### PR TITLE
problem: wrong socket type on PUSH_ZYRE_GATEWAY

### DIFF
--- a/csirtg_smrt/client/zzmq.py
+++ b/csirtg_smrt/client/zzmq.py
@@ -16,7 +16,7 @@ ENDPOINT = os.environ.get('CSIRTG_SMRT_ZMQ_ENDPOINT', 'ipc:///tmp/csirtg_smrt.ip
 TYPE_MAPPING = {
     'PUB': zmq.PUB,
     'PUSH': zmq.PUSH,
-    'PUSH_ZYRE_GATEWAY': zmq.PUSH,
+    'PUSH_ZYRE_GATEWAY': zmq.DEALER,
 }
 
 logger = logging.getLogger()


### PR DESCRIPTION
The new C gateway uses a ROUTER socket to enable bidirectional
communication so heartbeets can be implemented.