### PR TITLE
problem: bro log parser isn't stripping newline

### DIFF
--- a/csirtg_smrt/parser/bro.py
+++ b/csirtg_smrt/parser/bro.py
@@ -53,7 +53,7 @@ class BroTailer(object):
         if not len(line):
             return
 
-        parts = line.split(self.sep)
+        parts = line.rstrip().split(self.sep)
 
         record = dict(zip(self.fields, parts))
 


### PR DESCRIPTION
This is causing data like

    "remote_location.longitude": "-\n",

Fix: strip the newline befire splitting